### PR TITLE
Update Firmenweitergabe

### DIFF
--- a/Aktien-Game-V1/Aktien-Game-Sarius-1-patch-2/Moritz-Game/UserInputs/src/Account.java
+++ b/Aktien-Game-V1/Aktien-Game-Sarius-1-patch-2/Moritz-Game/UserInputs/src/Account.java
@@ -413,25 +413,13 @@ public class Account {
         System.out.println("Aktuelle Mitarbeiterzahl: " + mitarbeiter[merker]);
         if (mitarbeiter[merker] >= 1) {
             System.out.print("Aktuelle Mitarbeiterzufriedenheit: ");
-            switch (mitarbeiterzuf[merker]) {
-                case 1:
-                    System.out.println("sehr unglücklich");
-                    break;
-                case 2:
-                    System.out.println("unglücklich");
-                    break;
-                case 3:
-                    System.out.println("zufrieden");
-                    break;
-                case 4:
-                    System.out.println("glücklich");
-                    break;
-                case 5:
-                    System.out.println("sehr glücklich");
-                    break;
-                case 0:
-                    System.out.println("FEHLER");
-                    break;
+            switch (mitarbeiterzuf[merker]){
+                case 1: System.out.println("sehr unglücklich"); break;
+                case 2: System.out.println("unglücklich"); break;
+                case 3: System.out.println("zufrieden"); break;
+                case 4: System.out.println("glücklich"); break;
+                case 5: System.out.println("sehr glücklich"); break;
+                case 0: System.out.println("FEHLER"); break;
             }
         } else {
             System.out.println("Aktuelle Mitarbeiterzufriedenheit: -");


### PR DESCRIPTION
Patchnotes:
- Von jeder Firma nun nur noch 40 Aktien erhältlich (nicht je Nutzer, sondern insgesamt)
- Bei Firmenauflösung durch "sell" oder wenn der Inhaber alle seine Aktien verkauft bekommt der Nutzer, der die meisten Aktien dieser Firma hält, die Möglichkeit, die Firma zu übernehmen
- Ist eine Firmenauflösung im Gange und der Nutzer, dem die Firma zusteht, hat diese noch nicht bearbeitet, ist das Relaunchen nicht möglich, um den Kurs der Firma zu halten
- Möglichkeit, von Aktienmarkt direkt zum Firmenmenü und umgekehrt springen

Bugs/Für den nächsten Patch:
- Weitere Aktionäre verlieren ihre Aktien, falls der Nutzer die Firma nicht übernimmt (Lösung?)
- Haben mehrere Nutzer die gleiche Anzahl an Aktien soll zufällig ausgelost werden, wer zuerst Anspruch erhält